### PR TITLE
Fix for : https://github.com/1bye/time-picker-svelte/issues/2

### DIFF
--- a/src/lib/snippets/shadcn-svelte-runes/time-picker-input.svelte
+++ b/src/lib/snippets/shadcn-svelte-runes/time-picker-input.svelte
@@ -1,13 +1,13 @@
 <script lang="ts" module>
-	import type { HTMLInputAttributes } from 'svelte/elements';
-	import type { WithElementRef } from 'bits-ui';
 	import type { Time as TimeType } from '@internationalized/date';
+	import type { WithElementRef } from 'bits-ui';
+	import type { HTMLInputAttributes } from 'svelte/elements';
 
 	export type TimePickerInputProps = WithElementRef<HTMLInputAttributes> & {
 		type?: string;
 		value?: string;
 		name?: string;
-
+		files?: FileList | undefined;
 		picker: TimePickerType;
 		time: TimeType | undefined;
 		setTime?: (time: TimeType) => void;
@@ -18,10 +18,9 @@
 </script>
 
 <script lang="ts">
-	import { Time } from '@internationalized/date';
 	import { Input } from '$lib/components/ui/input';
 	import { cn } from '$lib/utils';
-
+	import { Time } from '@internationalized/date';
 	import {
 		type Period,
 		type TimePickerType,
@@ -34,6 +33,8 @@
 		class: className,
 		type = 'tel',
 		value,
+		files = $bindable(),
+
 		id,
 		name,
 		time = $bindable(new Time(0, 0)),
@@ -52,36 +53,38 @@
 	}: TimePickerInputProps = $props();
 
 	let flag = $state<boolean>(false);
-	let intKey = $state<string>('0');
 
-	let calculatedValue = $derived(getDateByType(time, picker));
+	// derived display value, updates when `time` or `picker` change
+	let calculatedValue = $derived.by(() => getDateByType(time, picker));
 
 	$effect(() => {
 		if (flag) {
 			const timer = setTimeout(() => {
 				flag = false;
 			}, 2000);
-
 			return () => clearTimeout(timer);
 		}
 	});
 
 	function calculateNewValue(key: string) {
-		/*
-		 * If picker is '12hours' and the first digit is 0, then the second digit is automatically set to 1.
-		 * The second entered digit will break the condition and the value will be set to 10-12.
-		 */
-		if (picker === '12hours') {
-			if (flag && calculatedValue.slice(1, 2) === '1' && intKey === '0') return '0' + key;
-		}
+		const cur = calculatedValue.padStart(2, '0');
+		const raw = flag ? cur[0] + key : key + cur[1];
+		let num = Number.parseInt(raw, 10);
 
-		return !flag ? '0' + key : calculatedValue.slice(1, 2) + key;
+		num = picker === '12hours' ? Math.min(Math.max(num, 1), 12) : Math.min(Math.max(num, 0), 23);
+
+		return String(num).padStart(2, '0');
 	}
 
 	function handleKeyDown(e: KeyboardEvent) {
 		if (e.key === 'Tab') return;
 
-		e.preventDefault();
+		const isNavKey = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key);
+		const isDigit = e.key >= '0' && e.key <= '9';
+
+		if (isNavKey || isDigit) {
+			e.preventDefault();
+		}
 
 		if (e.key === 'ArrowRight') onRightFocus?.();
 		if (e.key === 'ArrowLeft') onLeftFocus?.();
@@ -93,19 +96,17 @@
 			if (flag) flag = false;
 
 			const tempTime = time.copy();
-
 			time = setDateByType(tempTime, newValue, picker, period);
 			setTime?.(time);
 		}
-		if (e.key >= '0' && e.key <= '9') {
-			if (picker === '12hours') intKey = e.key;
 
-			const newValue = calculateNewValue(e.key);
+		if (isDigit) {
+			const newVal = calculateNewValue(e.key);
 			if (flag) onRightFocus?.();
 			flag = !flag;
 
 			const tempTime = time.copy();
-			time = setDateByType(tempTime, newValue, picker, period);
+			time = setDateByType(tempTime, newVal, picker, period);
 			setTime?.(time);
 		}
 	}
@@ -130,5 +131,4 @@
 		onkeydown?.(e);
 		handleKeyDown(e);
 	}}
-	{...restProps}
-/>
+	{...restProps} />


### PR DESCRIPTION
## Pull Request Description
This PR fixes the two-digit entry bug in our `TimePickerInput` component and cleans up the key-handling logic:

1. **Reactive Display Value**  
   - Switched to using  
     ```ts
     let calculatedValue = $derived.by(() => getDateByType(time, picker));
     ```  
     so `calculatedValue` now automatically updates whenever `time` or `picker` change.

2. **Simplified Digit Assembly**  
   - Replaced the convoluted special-case logic with a single `calculateNewValue` that:
     1. Pads the current display to two digits.
     2. Inserts the new key into the tens or ones place based on a `flag`.
     3. Clamps to valid ranges (1–12 for 12-hour, 0–23 for 24-hour).
     4. Re-pads to two characters.  
   - Guarantees typing “10” yields “10,” typing “00” in 12-hour mode clamps to “01,” etc.

3. **Scoped `preventDefault()`**  
   - Now only prevents default behavior for digit and arrow keys; leaves Backspace, Tab, Delete, etc., untouched.

4. **Maintained Focus Hooks & Steppers**  
   - Arrow-up/down still increment/decrement via `getArrowByType` and update `time` correctly.  
   - Left/right arrows still invoke `onLeftFocus`/`onRightFocus`.


Resolves **[This issue](https://github.com/1bye/time-picker-svelte/issues/2)**. Please review!